### PR TITLE
Bump deps, switch to http-kit

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :url "http://github.com/stanistan/flickr-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [cheshire "4.0.3"]
-                 [clj-http "0.5.5"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [cheshire "5.4.0"]
+                 [http-kit "2.1.18"]])

--- a/src/cacheable_client/core.clj
+++ b/src/cacheable_client/core.clj
@@ -1,7 +1,7 @@
 (ns cacheable-client.core
   (:use cacheable.common
         utils.common)
-  (:require [clj-http.client :as client]
+  (:require [org.httpkit.client :as client]
             cacheable.disk
             cacheable.atom))
 


### PR DESCRIPTION
http-kit is 100% clojure, very performant, and is actually a smaller
library (http://stackoverflow.com/a/24608936/1146898)
